### PR TITLE
Non-string response bodies

### DIFF
--- a/src/http.lisp
+++ b/src/http.lisp
@@ -21,7 +21,9 @@ lexical let.")
 @cl:param(status) code."
   (list status
         (list :content-type type)
-        (list body)))
+        (typecase body
+          (string (list body))
+          (otherwise body))))
 
 (defun redirect (url &key (status 302))
   "Redirect a user to @cl:param(url), optionally specifying a status code

--- a/t/lucerne.lisp
+++ b/t/lucerne.lisp
@@ -45,7 +45,12 @@
     @route app (:post "/post")
     (defview post-test ()
       (with-params (a b)
-        (respond (format nil "~A ~A" a b))))))
+        (respond (format nil "~A ~A" a b)))))
+  (finishes
+    @route app "/binary"
+    (defview binary-test ()
+      (respond (coerce '(1 2 3) '(vector (unsigned-byte 8)))
+               :type "application/octet-stream"))))
 
 (test (bring-up :depends-on define-routes)
   (is-true
@@ -79,6 +84,9 @@
                                :method :post
                                :parameters '(("a" . "1")
                                              ("b" . "2")))))
+  (is
+   (equalp #(1 2 3)
+           (drakma:http-request (make-url "binary"))))
   (is
    (equal "Not found"
           (drakma:http-request (make-url "no-such-view")))))


### PR DESCRIPTION
Great work on the framework! I really like how it's laid out.

Today I needed to return some binary data for one of my views and found that `respond` only accepted a string body. So here's a quick fix that lets you use vectors and pathnames as well.