### PR TITLE
Specify the body argument of DEFVIEW as &BODY

### DIFF
--- a/src/views.lisp
+++ b/src/views.lisp
@@ -67,7 +67,7 @@ function @cl:param(fn)."
            ,(first config)
            ,body))))
 
-(defmacro defview (name (&rest args) &rest body)
+(defmacro defview (name (&rest args) &body body)
   "Define a view. The body of the view implicitly has access to the global
 request object @c(*request*)."
   (alexandria:with-gensyms (params)


### PR DESCRIPTION
This improves the automatic indentation in Emacs, as &BODY arguments are
indented two spaces. With &REST, as it was previously, the body would be
aligned with previous arguments.