### PR TITLE
Fix skeleton:make-project for sbcl.

### DIFF
--- a/skeleton/src/source.lisp
+++ b/skeleton/src/source.lisp
@@ -4,6 +4,7 @@
   (:export :app)
   (:documentation "Main {{name}} code."))
 (in-package :{{name}})
+(annot:enable-annot-syntax)
 
 ;;; App
 

--- a/src/skeleton.lisp
+++ b/src/skeleton.lisp
@@ -31,7 +31,8 @@
 
 (defun parse-systems-list (systems-list)
   (loop for system-name
-        in (split-sequence:split-sequence #\, systems-list)
+        in (remove-if (lambda (x) (string= "" x))
+                      (split-sequence:split-sequence #\, systems-list))
         collecting
         (strip-whitespace system-name)))
 
@@ -43,6 +44,7 @@
            (let ((string (apply #'format (append (list nil format-string)
                                                  args))))
              (format t "~%~A: " string)
+             (finish-output nil)
              (read-line)))
          (yes-or-no (format-string &rest args)
            (apply #'yes-or-no-p (cons format-string args))))


### PR DESCRIPTION
I've tried to run `(lucerne.skeleton:make-project)` with sbcl and found following troubles:

1. Because of line-buffering the "wizard" waits for answer and then asks a question.

2. If i just press return on question `"Dependencies (e.g. 'drakma, quri, clack')"` i get in my-app.asd following bug:  
   ```
:depends-on (:lucerne
                 :)
   ```

3. forgotten `(annot:enable-annot-syntax)`

Thanks for such pretty framework:)