### PR TITLE
Add a missing word in the overview page of the document.

### DIFF
--- a/docs/overview.scr
+++ b/docs/overview.scr
@@ -12,7 +12,7 @@ Lucerne is a web application framework built on
 @term(Built on Clack)
 @def(Lucerne uses @link[uri=http://clacklisp.org/](Clack), an HTTP server
 abstraction, which enables it to use any server backend supported by Clack
-@l(ndash) from Hunchentoot the the very fast
+@l(ndash) from Hunchentoot to the the very fast
 @link[uri="https://github.com/fukamachi/woo"](Woo).)
 
 @term(Inspired by Flask)


### PR DESCRIPTION
In the overview page of the document, there is a missing word in the 'Built on Clack' feature paragraph. This commit adds the missing word. 