### PR TITLE
Added clack startup option for address

### DIFF
--- a/src/control.lisp
+++ b/src/control.lisp
@@ -14,7 +14,7 @@ error -- This is particularly common in testing. By using this system, we don't
 leak ports and prevent 'address in use' errors."))
 (in-package :lucerne.ctl)
 
-(defmethod start ((app base-app) &key (port 8000) (server :hunchentoot) debug silent)
+(defmethod start ((app base-app) &key (port 8000) (server :hunchentoot) (address "127.0.0.1") debug silent)
   "Bring up @cl:param(app), by default on @cl:param(port) 8000. If the server
 was not running, it returns @c(T). If the server was running, it restarts it and
 returns @c(NIL)."
@@ -34,6 +34,7 @@ returns @c(NIL)."
                                clack-app)))
            :port port
            :server server
+           :address address
            :use-default-middlewares nil
            :silent silent))
     (sleep 1)


### PR DESCRIPTION
Adds the the address option to 'start', defaulting to "127.0.0.1".  This should resolve [this issue](https://github.com/eudoxia0/lucerne/issues/27).